### PR TITLE
Add git repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.5",
   "description": "Toggl command line utility",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gorangajic/node-toggl.git"
+  },
   "bin": {
     "toggl": "./bin/toggl"
   },


### PR DESCRIPTION
If you head over to this repository page in the NPM registry, a link to this repository is absent. By adding the repository URL to this JSON file, the NPM registry should show a link to this repository once you publish this module with this new JSON file.